### PR TITLE
Do not truncate ELB policies.

### DIFF
--- a/plugins/ec2/insecureCiphers.js
+++ b/plugins/ec2/insecureCiphers.js
@@ -153,16 +153,6 @@ module.exports = {
 					return rcb();
 				}
 
-				if (policies.length > 30) {
-					pluginInfo.tests.insecureCiphers.results.push({
-						status: 3,
-						message: 'More than 30 load balancers found. Only the first 30 are checked.',
-						region: region
-					});
-
-					policies = policies.slice(0,30);
-				}
-
 				async.eachLimit(policies, 4, function(policy, cb){
 					elb.describeLoadBalancerPolicies(policy, function(err, data){
 						if (err || !data || !data.PolicyDescriptions) {


### PR DESCRIPTION
I'm not sure why this truncation logic was put into place (performance?). Since the scans depend on the official AWS SDK it appears the API pagination works as expected. Removing the logic from my fork returns results for all of our ELBs (> 100) as expected.