### PR TITLE
Use AWS credentials from environment by default.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 var async = require('async');
 
-// var AWSConfig = {
-//     accessKeyId: '',
-//     secretAccessKey: '',
-//     sessionToken: '',
-//     region: 'us-east-1'
-// };
+var AWSConfig = {
+    accessKeyId:     process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    sessionToken:    process.env.AWS_SESSION_TOKEN,
+    region:          process.env.AWS_DEFAULT_REGION
+};
 
-var AWSConfig = require(__dirname + '/../../cloudsploit-secure/scan-test-credentials.json');
+// var AWSConfig = require(__dirname + '/../../cloudsploit-secure/scan-test-credentials.json');
 
 var plugins = [
     'iam/rootAccountSecurity.js',


### PR DESCRIPTION
Enables retrieving AWS credentials from the environment. Makes the Cloudsploit scans work as a pure [12-factor app](http://12factor.net/config). Really useful when externally injecting the config from configuration management and/or hosting inside of a container (Docker).

e.g.

```
docker run --env-file aws-creds.env cloudsploit > advisories.log
```