### PR TITLE
Use default AWS SDK credential resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install
 ```
 
 ## Setup
-To begin using the scanner, edit the index.js file with your AWS key, secret, and optionally (for temporary credentials), a session token. In the list of plugins, comment out any plugins you do not wish to run. Then save and run ```node index.js```.
+To begin using the scanner, supply your AWS credentials using one of the methods outlined in the [official AWS SDK guide](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Setting_AWS_Credentials) or manually edit the index.js file with your key, secret, and optionally (for temporary credentials), a session token. In the list of plugins, comment out any plugins you do not wish to run. Then save and run ```node index.js```.
 
 ### Cross Account Roles
 When using the [hosted scanner](https://cloudsploit.com/scan), you'll need to create a cross-account IAM role. Cross-account roles enable you to share access to your account with another AWS account using the same policy model that you're used to. The advantage is that cross-account roles are much more secure than key-based access, since an attacker who steals a cross-account role ARN still can't make API calls unless they also infiltrate the authorized AWS account.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,20 @@
 var async = require('async');
+var AWS = require('aws-sdk');
+
+//
+// Default to the AWS SDK credential lookup behavior which searches in the following order.
+//
+// 1. Loaded from IAM roles for Amazon EC2 (if running on EC2),
+// 2. Loaded from the shared credentials file (~/.aws/credentials),
+// 3. Loaded from environment variables,
+// 4. Loaded from a JSON file on disk,
+// 5. Hardcoded in your application
+//
+// see: http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Setting_AWS_Credentials
+//
+// The credentials can be configured manually by using one of the code blocks below.
+//
+var AWSConfig = AWS.config
 
 // var AWSConfig = {
 //     accessKeyId: '',
@@ -7,7 +23,7 @@ var async = require('async');
 //     region: 'us-east-1'
 // };
 
-var AWSConfig = require(__dirname + '/../../cloudsploit-secure/scan-test-credentials.json');
+// var AWSConfig = require(__dirname + '/../../cloudsploit-secure/scan-test-credentials.json');
 
 var plugins = [
     'iam/rootAccountSecurity.js',


### PR DESCRIPTION
This is an improvement to my original pull request (#7) to fetch credentials from the environment. I've updated index.js to fetch credentials using the method outlined in the [official AWS SDK documentation](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Setting_AWS_Credentials). I think it's a minor improvement that makes the code a bit more portable.
