### PR TITLE
Remove debug log message.

### DIFF
--- a/plugins/rds/databaseSecurity.js
+++ b/plugins/rds/databaseSecurity.js
@@ -63,8 +63,6 @@ module.exports = {
 			AWSConfig.region = region;
 			var rds = new AWS.RDS(AWSConfig);
 
-			console.log('Running for: ' + region);
-
 			rds.describeDBInstances({}, function(err, data){
 				if (err || !data) {
 					var statusObj = {


### PR DESCRIPTION
This removes an extraneous debug message from the console log. AFAICT, the database plugin is the only one logging the region as it iterates. None of the others seem to do this.