### PR TITLE
Remove API result limits

### DIFF
--- a/plugins/ec2/certificateExpiry.js
+++ b/plugins/ec2/certificateExpiry.js
@@ -33,7 +33,7 @@ module.exports = {
 		var iam = new AWS.IAM(AWSConfig);
 		var pluginInfo = getPluginInfo();
 
-		iam.listServerCertificates({MaxItems:100}, function(err, data){
+		iam.listServerCertificates(function(err, data){
 			if (err || !data || !data.ServerCertificateMetadataList) {
 				pluginInfo.tests.certificateExpiry.results.push({
 					status: 3,

--- a/plugins/route53/domainSecurity.js
+++ b/plugins/route53/domainSecurity.js
@@ -54,7 +54,7 @@ module.exports = {
 
 		var route53domains = new AWS.Route53Domains(AWSConfig);
 
-		route53domains.listDomains({MaxItems:100}, function(err, data){
+		route53domains.listDomains(function(err, data){
 			if (err || !data) {
 				var statusObj = {
 					status: 3,


### PR DESCRIPTION
Removes a couple of API max item limits. AFAICT, there isn't any reason to limit the results.