### PR TITLE
Don't flag RDS read replicas for restore time

### DIFF
--- a/plugins/rds/databaseSecurity.js
+++ b/plugins/rds/databaseSecurity.js
@@ -175,7 +175,8 @@ module.exports = {
 						}
 
 						pluginInfo.tests.rdsRestorable.results.push(statusObj);
-					} else {
+					} else if (!data.DBInstances[i].ReadReplicaSourceDBInstanceIdentifier) {
+						// Apply rule to everything else except Read replicas
 						pluginInfo.tests.rdsRestorable.results.push({
 							status: 2,
 							message: 'RDS instance does not have a restorable time',


### PR DESCRIPTION
Seems like in general, a read replica doesn't need a restore time defined. This created a lot of noise in some security scans so filtering it out by default seemed acceptable.