### PR TITLE
Removing __dirname for browserify compatibility

### DIFF
--- a/exports.js
+++ b/exports.js
@@ -1,26 +1,26 @@
 // Export all available scans
 
 module.exports = {
-	'cloudtrailBucketDelete': require(__dirname + '/plugins/cloudtrail/cloudtrailBucketDelete.js'),
-	'cloudtrailEnabled': require(__dirname + '/plugins/cloudtrail/cloudtrailEnabled.js'),
+	'cloudtrailBucketDelete': require('./plugins/cloudtrail/cloudtrailBucketDelete.js'),
+	'cloudtrailEnabled': require('./plugins/cloudtrail/cloudtrailEnabled.js'),
 
-	'accountLimits': require(__dirname + '/plugins/ec2/accountLimits.js'),
-	'securityGroups': require(__dirname + '/plugins/ec2/securityGroups.js'),
+	'accountLimits': require('./plugins/ec2/accountLimits.js'),
+	'securityGroups': require('./plugins/ec2/securityGroups.js'),
 
-	'certificateExpiry': require(__dirname + '/plugins/ec2/certificateExpiry.js'),
-	'insecureCiphers': require(__dirname + '/plugins/ec2/insecureCiphers.js'),
+	'certificateExpiry': require('./plugins/ec2/certificateExpiry.js'),
+	'insecureCiphers': require('./plugins/ec2/insecureCiphers.js'),
 
-	'passwordPolicy': require(__dirname + '/plugins/iam/passwordPolicy.js'),
-	'rootAccountSecurity': require(__dirname + '/plugins/iam/rootAccountSecurity.js'),
-	'usersMfaEnabled': require(__dirname + '/plugins/iam/usersMfaEnabled.js'),
-	'accessKeys': require(__dirname + '/plugins/iam/accessKeys.js'),
-	'groupSecurity': require(__dirname + '/plugins/iam/groupSecurity.js'),
+	'passwordPolicy': require('./plugins/iam/passwordPolicy.js'),
+	'rootAccountSecurity': require('./plugins/iam/rootAccountSecurity.js'),
+	'usersMfaEnabled': require('./plugins/iam/usersMfaEnabled.js'),
+	'accessKeys': require('./plugins/iam/accessKeys.js'),
+	'groupSecurity': require('./plugins/iam/groupSecurity.js'),
 	
-	'detectClassic': require(__dirname + '/plugins/vpc/detectClassic.js'),
+	'detectClassic': require('./plugins/vpc/detectClassic.js'),
 
-	's3Buckets': require(__dirname + '/plugins/s3/s3Buckets.js'),
+	's3Buckets': require('./plugins/s3/s3Buckets.js'),
 
-	'domainSecurity': require(__dirname + '/plugins/route53/domainSecurity.js'),
+	'domainSecurity': require('./plugins/route53/domainSecurity.js'),
 
-	'databaseSecurity': require(__dirname + '/plugins/rds/databaseSecurity.js')
+	'databaseSecurity': require('./plugins/rds/databaseSecurity.js')
 };

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var async = require('async');
 //     region: 'us-east-1'
 // };
 
-var AWSConfig = require(__dirname + '/../../cloudsploit-secure/scan-test-credentials.json');
+var AWSConfig = require('./../../cloudsploit-secure/scan-test-credentials.json');
 
 var plugins = [
     'iam/rootAccountSecurity.js',
@@ -30,7 +30,7 @@ var plugins = [
 console.log('CATEGORY\t\tPLUGIN\t\t\t\tTEST\t\t\t\tRESOURCE\t\t\tREGION\t\tSTATUS\tMESSAGE');
 
 async.eachSeries(plugins, function(pluginPath, callback){
-    var plugin = require(__dirname + '/plugins/' + pluginPath);
+    var plugin = require('./plugins/' + pluginPath);
 
     plugin.run(AWSConfig, function(err, result){
         //console.log(JSON.stringify(result, null, 2));

--- a/lambda.js
+++ b/lambda.js
@@ -1,10 +1,10 @@
 // Plugins can be executed by AWS Lambda
 // Pass in either an access_key and secret_key or an IAM execution role / external ID
 
-var plugins = require(__dirname + '/exports.js');
+var plugins = require('./exports.js');
 var AWS = require('aws-sdk');
 var sts = new AWS.STS({apiVersion: '2011-06-15'});
-var regions = require(__dirname + '/regions.json');
+var regions = require('./regions.json');
 
 function createSuccessResponse(data) {
     return {

--- a/plugins/cloudtrail/cloudtrailBucketDelete.js
+++ b/plugins/cloudtrail/cloudtrailBucketDelete.js
@@ -1,6 +1,6 @@
 var async = require('async');
 var AWS = require('aws-sdk');
-var regions = require(__dirname + '/../../regions.json');
+var regions = require('./../../regions.json');
 
 function getPluginInfo() {
 	return {

--- a/plugins/cloudtrail/cloudtrailEnabled.js
+++ b/plugins/cloudtrail/cloudtrailEnabled.js
@@ -1,5 +1,5 @@
 var AWS = require('aws-sdk');
-var regions = require(__dirname + '/../../regions.json');
+var regions = require('./../../regions.json');
 var async = require('async');
 
 function getPluginInfo() {

--- a/plugins/ec2/accountLimits.js
+++ b/plugins/ec2/accountLimits.js
@@ -1,6 +1,6 @@
 var AWS = require('aws-sdk');
 var async = require('async');
-var regions = require(__dirname + '/../../regions.json');
+var regions = require('./../../regions.json');
 
 function getPluginInfo() {
 	return {

--- a/plugins/ec2/insecureCiphers.js
+++ b/plugins/ec2/insecureCiphers.js
@@ -1,6 +1,6 @@
 var AWS = require('aws-sdk');
 var async = require('async');
-var regions = require(__dirname + '/../../regions.json');
+var regions = require('./../../regions.json');
 
 function getPluginInfo() {
 	return {

--- a/plugins/ec2/securityGroups.js
+++ b/plugins/ec2/securityGroups.js
@@ -1,6 +1,6 @@
 var AWS = require('aws-sdk');
 var async = require('async');
-var regions = require(__dirname + '/../../regions.json');
+var regions = require('./../../regions.json');
 
 function getPluginInfo() {
 	return {

--- a/plugins/rds/databaseSecurity.js
+++ b/plugins/rds/databaseSecurity.js
@@ -1,6 +1,6 @@
 var AWS = require('aws-sdk');
 var async = require('async');
-var regions = require(__dirname + '/../../regions.json');
+var regions = require('./../../regions.json');
 
 function getPluginInfo() {
 	return {

--- a/plugins/s3/s3Buckets.js
+++ b/plugins/s3/s3Buckets.js
@@ -1,6 +1,6 @@
 var async = require('async');
 var AWS = require('aws-sdk');
-var regions = require(__dirname + '/../../regions.json');
+var regions = require('./../../regions.json');
 
 function getPluginInfo() {
 	return {

--- a/plugins/vpc/detectClassic.js
+++ b/plugins/vpc/detectClassic.js
@@ -1,7 +1,7 @@
 var AWS = require('aws-sdk');
 var async = require('async');
 
-var regions = require(__dirname + '/../../regions.json');
+var regions = require('./../../regions.json');
 
 function getPluginInfo() {
 	return {


### PR DESCRIPTION
Using this package in browserify builds (such as in [JAWS-framework](https://github.com/jaws-framework/JAWS) for AWS) is not possible due to the use of `__dirname`. Removing this in favor of using relative paths with `./` works just as fine on node, and works on browserify too.

This does not change the functionality of the package or plugin in any way.
