### PR TITLE
"Include Source" Feature to Include Original AWS Source Responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ if (securityReport) {
 }
 
 async.forEachOfLimit(plugins, 10, function(plugin, key, callback){
-    plugin.run(AWSConfig, cache, function(err, results){
+    plugin.run(AWSConfig, cache, false, function(err, results){
         var benchmarkStatus = 'PASS';
         for (r in results) {
             var statusWord;

--- a/lambda.js
+++ b/lambda.js
@@ -41,7 +41,7 @@ var pluginRunner = function(event, context) {
         async.eachLimit(event.plugins, 10, function(pluginToRun, cb){
             console.log('Running: ' + pluginToRun);
             // Run the plugin requested
-            plugins[pluginToRun].run({}, cache, function(err, results){
+            plugins[pluginToRun].run({}, cache, false, function(err, results){
                 if (err) {
                     console.log(err);
                 } else {

--- a/plugins/cloudtrail/cloudtrailBucketAccessLogging.js
+++ b/plugins/cloudtrail/cloudtrailBucketAccessLogging.js
@@ -10,8 +10,9 @@ module.exports = {
 	recommended_action: 'Enable access logging on the CloudTrail bucket from the S3 console',
 	link: 'http://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.cloudtrail, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -21,6 +22,8 @@ module.exports = {
 			var cloudtrail = new AWS.CloudTrail(LocalAWSConfig);
 
 			helpers.cache(cache, cloudtrail, 'describeTrails', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err) {
 					results.push({
 						status: 3,
@@ -78,7 +81,7 @@ module.exports = {
 				}
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/cloudtrail/cloudtrailBucketDelete.js
+++ b/plugins/cloudtrail/cloudtrailBucketDelete.js
@@ -10,8 +10,9 @@ module.exports = {
 	recommended_action: 'Enable MFA delete on the CloudTrail bucket',
 	link: 'http://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html#MultiFactorAuthenticationDelete',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.cloudtrail, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -21,6 +22,8 @@ module.exports = {
 			var cloudtrail = new AWS.CloudTrail(LocalAWSConfig);
 
 			helpers.cache(cache, cloudtrail, 'describeTrails', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err) {
 					results.push({
 						status: 3,
@@ -78,7 +81,7 @@ module.exports = {
 				}
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/cloudtrail/cloudtrailBucketPrivate.js
+++ b/plugins/cloudtrail/cloudtrailBucketPrivate.js
@@ -10,8 +10,9 @@ module.exports = {
 	recommended_action: 'Set the S3 bucket access policy for all CloudTrail buckets to only allow known users to access its files.',
 	link: 'http://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.cloudtrail, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -21,6 +22,8 @@ module.exports = {
 			var cloudtrail = new AWS.CloudTrail(LocalAWSConfig);
 
 			helpers.cache(cache, cloudtrail, 'describeTrails', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err) {
 					results.push({
 						status: 3,
@@ -102,7 +105,7 @@ module.exports = {
 				}
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/cloudtrail/cloudtrailEnabled.js
+++ b/plugins/cloudtrail/cloudtrailEnabled.js
@@ -10,8 +10,9 @@ module.exports = {
 	recommended_action: 'Enable CloudTrail for all regions and ensure that at least one region monitors global service events',
 	link: 'http://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-getting-started.html',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		var globalServicesMonitored = false;
 
@@ -23,6 +24,8 @@ module.exports = {
 			var cloudtrail = new AWS.CloudTrail(LocalAWSConfig);
 
 			helpers.cache(cache, cloudtrail, 'describeTrails', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err) {
 					results.push({
 						status: 3,
@@ -84,7 +87,7 @@ module.exports = {
 				});
 			}
 
-			return callback(null, results);
+			return callback(null, results, source);
 		});
 	}
 };

--- a/plugins/cloudtrail/cloudtrailEncryption.js
+++ b/plugins/cloudtrail/cloudtrailEncryption.js
@@ -10,8 +10,9 @@ module.exports = {
 	recommended_action: 'Enable CloudTrail log encryption through the CloudTrail console or API',
 	link: 'http://docs.aws.amazon.com/awscloudtrail/latest/userguide/encrypting-cloudtrail-log-files-with-aws-kms.html',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.cloudtrail, helpers.MAX_REGIONS_AT_A_TIME, function(region, cb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -21,6 +22,8 @@ module.exports = {
 			var cloudtrail = new AWS.CloudTrail(LocalAWSConfig);
 
 			helpers.cache(cache, cloudtrail, 'describeTrails', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err) {
 					results.push({
 						status: 3,
@@ -76,7 +79,7 @@ module.exports = {
 				}
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/cloudtrail/cloudtrailFileValidation.js
+++ b/plugins/cloudtrail/cloudtrailFileValidation.js
@@ -10,8 +10,9 @@ module.exports = {
 	recommended_action: 'Enable CloudTrail file validation for all regions',
 	link: 'http://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-log-file-validation-enabling.html',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.cloudtrail, helpers.MAX_REGIONS_AT_A_TIME, function(region, cb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -21,6 +22,8 @@ module.exports = {
 			var cloudtrail = new AWS.CloudTrail(LocalAWSConfig);
 
 			helpers.cache(cache, cloudtrail, 'describeTrails', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err) {
 					results.push({
 						status: 3,
@@ -76,7 +79,7 @@ module.exports = {
 				}
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/cloudtrail/cloudtrailToCloudwatch.js
+++ b/plugins/cloudtrail/cloudtrailToCloudwatch.js
@@ -10,8 +10,9 @@ module.exports = {
 	recommended_action: 'Enable CloudTrail CloudWatch integration for all regions',
 	link: 'http://docs.aws.amazon.com/awscloudtrail/latest/userguide/send-cloudtrail-events-to-cloudwatch-logs.html',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.cloudtrail, helpers.MAX_REGIONS_AT_A_TIME, function(region, cb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -21,6 +22,8 @@ module.exports = {
 			var cloudtrail = new AWS.CloudTrail(LocalAWSConfig);
 
 			helpers.cache(cache, cloudtrail, 'describeTrails', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err) {
 					results.push({
 						status: 3,
@@ -76,7 +79,7 @@ module.exports = {
 				}
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/defaultSecurityGroup.js
+++ b/plugins/ec2/defaultSecurityGroup.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#default-security-group',
 	recommended_action: 'Update the rules for the default security group to deny all traffic by default',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -22,6 +23,8 @@ module.exports = {
 
 			// Get the account attributes
 			helpers.cache(cache, ec2, 'describeSecurityGroups', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err || !data || !data.SecurityGroups) {
 					results.push({
 						status: 3,
@@ -66,7 +69,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/elasticIpLimit.js
+++ b/plugins/ec2/elasticIpLimit.js
@@ -10,8 +10,9 @@ module.exports = {
 	recommended_action: 'Contact AWS support to increase the number of EIPs available',
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html#using-instance-addressing-limit',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -26,7 +27,12 @@ module.exports = {
 			};
 
 			// Get the account attributes
+			if (includeSource) source['describeAccountAttributes'] = {};
+			if (includeSource) source['describeAddresses'] = {};
+
 			helpers.cache(cache, ec2, 'describeAccountAttributes', function(err, data) {
+				if (includeSource) source['describeAccountAttributes'][region] = {error: err, data: data};
+
 				if (err || !data || !data.AccountAttributes || !data.AccountAttributes.length) {
 					results.push({
 						status: 3,
@@ -45,6 +51,8 @@ module.exports = {
 				}
 				
 				helpers.cache(cache, ec2, 'describeAddresses', function(err, data) {
+					if (includeSource) source['describeAddresses'][region] = {error: err, data: data};
+
 					if (err || !data || !data.Addresses) {
 						results.push({
 							status: 3,
@@ -92,7 +100,7 @@ module.exports = {
 				});
 			});
 		}, function(){
-			return callback(null, results);
+			return callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/excessiveSecurityGroups.js
+++ b/plugins/ec2/excessiveSecurityGroups.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html',
 	recommended_action: 'Limit the number of security groups to prevent accidental authorizations',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -22,6 +23,8 @@ module.exports = {
 
 			// Get the account attributes
 			helpers.cache(cache, ec2, 'describeSecurityGroups', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err || !data || !data.SecurityGroups) {
 					results.push({
 						status: 3,
@@ -65,7 +68,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/insecureCiphers.js
+++ b/plugins/ec2/insecureCiphers.js
@@ -84,8 +84,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/elb-security-policy-options.html',
 	recommended_action: 'Update your ELBs to use the reccommended cipher suites',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.elb, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -95,6 +96,8 @@ module.exports = {
 			var elb = new AWS.ELB(LocalAWSConfig);
 
 			helpers.cache(cache, elb, 'describeLoadBalancers', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err || !data || !data.LoadBalancerDescriptions) {
 					results.push({
 						status: 3,
@@ -179,7 +182,7 @@ module.exports = {
 				});
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/instanceLimit.js
+++ b/plugins/ec2/instanceLimit.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html#using-instance-addressing-limit',
 	recommended_action: 'Contact AWS support to increase the number of instances available',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -26,7 +27,12 @@ module.exports = {
 			};
 
 			// Get the account attributes
+			if (includeSource) source['describeAccountAttributes'] = {};
+			if (includeSource) source['describeInstances'] = {};
+
 			helpers.cache(cache, ec2, 'describeAccountAttributes', function(err, data) {
+				if (includeSource) source['describeAccountAttributes'][region] = {error: err, data: data};
+
 				if (err || !data || !data.AccountAttributes || !data.AccountAttributes.length) {
 					results.push({
 						status: 3,
@@ -46,6 +52,8 @@ module.exports = {
 				
 				// Now call APIs to determine actual usage
 				helpers.cache(cache, ec2, 'describeInstances', function(err, data) {
+					if (includeSource) source['describeInstances'][region] = {error: err, data: data};
+
 					if (err || !data || !data.Reservations) {
 						results.push({
 							status: 3,
@@ -74,7 +82,7 @@ module.exports = {
 				});
 			});
 		}, function(){
-			return callback(null, results);
+			return callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/openCIFS.js
+++ b/plugins/ec2/openCIFS.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html',
 	recommended_action: 'Restrict UDP port 445 to known IP addresses',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -22,6 +23,8 @@ module.exports = {
 
 			// Get the account attributes
 			helpers.cache(cache, ec2, 'describeSecurityGroups', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err || !data || !data.SecurityGroups) {
 					results.push({
 						status: 3,
@@ -74,7 +77,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/openDNS.js
+++ b/plugins/ec2/openDNS.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html',
 	recommended_action: 'Restrict TCP and UDP port 53 to known IP addresses',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -22,6 +23,8 @@ module.exports = {
 
 			// Get the account attributes
 			helpers.cache(cache, ec2, 'describeSecurityGroups', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err || !data || !data.SecurityGroups) {
 					results.push({
 						status: 3,
@@ -74,7 +77,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/openFTP.js
+++ b/plugins/ec2/openFTP.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html',
 	recommended_action: 'Restrict TCP ports 20 and 21 to known IP addresses',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -22,6 +23,8 @@ module.exports = {
 
 			// Get the account attributes
 			helpers.cache(cache, ec2, 'describeSecurityGroups', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err || !data || !data.SecurityGroups) {
 					results.push({
 						status: 3,
@@ -74,7 +77,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/openMySQL.js
+++ b/plugins/ec2/openMySQL.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html',
 	recommended_action: 'Restrict TCP ports 4333 and 3306 to known IP addresses',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -22,6 +23,8 @@ module.exports = {
 
 			// Get the account attributes
 			helpers.cache(cache, ec2, 'describeSecurityGroups', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err || !data || !data.SecurityGroups) {
 					results.push({
 						status: 3,
@@ -74,7 +77,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/openNetBIOS.js
+++ b/plugins/ec2/openNetBIOS.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html',
 	recommended_action: 'Restrict UDP ports 137 and 138 to known IP addresses',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -22,6 +23,8 @@ module.exports = {
 
 			// Get the account attributes
 			helpers.cache(cache, ec2, 'describeSecurityGroups', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err || !data || !data.SecurityGroups) {
 					results.push({
 						status: 3,
@@ -74,7 +77,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/openPostgreSQL.js
+++ b/plugins/ec2/openPostgreSQL.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html',
 	recommended_action: 'Restrict TCP port 5432 to known IP addresses',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -22,6 +23,8 @@ module.exports = {
 
 			// Get the account attributes
 			helpers.cache(cache, ec2, 'describeSecurityGroups', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err || !data || !data.SecurityGroups) {
 					results.push({
 						status: 3,
@@ -74,7 +77,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/openRDP.js
+++ b/plugins/ec2/openRDP.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html',
 	recommended_action: 'Restrict TCP port 3389 to known IP addresses',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -22,6 +23,8 @@ module.exports = {
 
 			// Get the account attributes
 			helpers.cache(cache, ec2, 'describeSecurityGroups', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err || !data || !data.SecurityGroups) {
 					results.push({
 						status: 3,
@@ -74,7 +77,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/openRPC.js
+++ b/plugins/ec2/openRPC.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html',
 	recommended_action: 'Restrict TCP port 135 to known IP addresses',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -22,6 +23,8 @@ module.exports = {
 
 			// Get the account attributes
 			helpers.cache(cache, ec2, 'describeSecurityGroups', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err || !data || !data.SecurityGroups) {
 					results.push({
 						status: 3,
@@ -74,7 +77,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/openSMBoTCP.js
+++ b/plugins/ec2/openSMBoTCP.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html',
 	recommended_action: 'Restrict TCP port 445 to known IP addresses',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -22,6 +23,8 @@ module.exports = {
 
 			// Get the account attributes
 			helpers.cache(cache, ec2, 'describeSecurityGroups', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err || !data || !data.SecurityGroups) {
 					results.push({
 						status: 3,
@@ -74,7 +77,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/openSMTP.js
+++ b/plugins/ec2/openSMTP.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html',
 	recommended_action: 'Restrict TCP port 25 to known IP addresses',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -22,6 +23,8 @@ module.exports = {
 
 			// Get the account attributes
 			helpers.cache(cache, ec2, 'describeSecurityGroups', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err || !data || !data.SecurityGroups) {
 					results.push({
 						status: 3,
@@ -74,7 +77,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/openSQLServer.js
+++ b/plugins/ec2/openSQLServer.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html',
 	recommended_action: 'Restrict TCP port 1433 and UDP port 1434 to known IP addresses',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -22,6 +23,8 @@ module.exports = {
 
 			// Get the account attributes
 			helpers.cache(cache, ec2, 'describeSecurityGroups', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err || !data || !data.SecurityGroups) {
 					results.push({
 						status: 3,
@@ -74,7 +77,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/openSSH.js
+++ b/plugins/ec2/openSSH.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html',
 	recommended_action: 'Restrict TCP port 22 to known IP addresses',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -22,6 +23,8 @@ module.exports = {
 
 			// Get the account attributes
 			helpers.cache(cache, ec2, 'describeSecurityGroups', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err || !data || !data.SecurityGroups) {
 					results.push({
 						status: 3,
@@ -74,7 +77,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/openTelnet.js
+++ b/plugins/ec2/openTelnet.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html',
 	recommended_action: 'Restrict TCP port 23 to known IP addresses',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -22,6 +23,8 @@ module.exports = {
 
 			// Get the account attributes
 			helpers.cache(cache, ec2, 'describeSecurityGroups', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err || !data || !data.SecurityGroups) {
 					results.push({
 						status: 3,
@@ -74,7 +77,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/openVNCClient.js
+++ b/plugins/ec2/openVNCClient.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html',
 	recommended_action: 'Restrict TCP port 5500 to known IP addresses',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -22,6 +23,8 @@ module.exports = {
 
 			// Get the account attributes
 			helpers.cache(cache, ec2, 'describeSecurityGroups', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err || !data || !data.SecurityGroups) {
 					results.push({
 						status: 3,
@@ -74,7 +77,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/openVNCServer.js
+++ b/plugins/ec2/openVNCServer.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html',
 	recommended_action: 'Restrict TCP port 5900 to known IP addresses',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -22,6 +23,8 @@ module.exports = {
 
 			// Get the account attributes
 			helpers.cache(cache, ec2, 'describeSecurityGroups', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+
 				if (err || !data || !data.SecurityGroups) {
 					results.push({
 						status: 3,
@@ -74,7 +77,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/ec2/vpcElasticIpLimit.js
+++ b/plugins/ec2/vpcElasticIpLimit.js
@@ -10,8 +10,9 @@ module.exports = {
 	recommended_action: 'Contact AWS support to increase the number of EIPs available',
 	link: 'http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html#using-instance-addressing-limit',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.ec2, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -26,7 +27,12 @@ module.exports = {
 			};
 
 			// Get the account attributes
+			if (includeSource) source['describeAccountAttributes'] = {};
+			if (includeSource) source['describeAddresses'] = {};
+
 			helpers.cache(cache, ec2, 'describeAccountAttributes', function(err, data) {
+				if (includeSource) source['describeAccountAttributes'][region] = {error: err, data: data};
+
 				if (err || !data || !data.AccountAttributes || !data.AccountAttributes.length) {
 					results.push({
 						status: 3,
@@ -45,6 +51,8 @@ module.exports = {
 				}
 				
 				helpers.cache(cache, ec2, 'describeAddresses', function(err, data) {
+					if (includeSource) source['describeAddresses'][region] = {error: err, data: data};
+					
 					if (err || !data || !data.Addresses) {
 						results.push({
 							status: 3,
@@ -92,7 +100,7 @@ module.exports = {
 				});
 			});
 		}, function(){
-			return callback(null, results);
+			return callback(null, results, source);
 		});
 	}
 };

--- a/plugins/iam/accessKeysExtra.js
+++ b/plugins/iam/accessKeysExtra.js
@@ -10,9 +10,10 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingCredentials.html',
 	recommended_action: 'Remove the extra access key for the specified user.',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 
 		var results = [];
+		var source = {};
 
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -22,6 +23,8 @@ module.exports = {
 		var iam = new AWS.IAM(LocalAWSConfig);
 
 		helpers.functions.waitForCredentialReport(iam, function(err, data){
+			if (includeSource) source.global = {error: err, data: []};
+
 			if (err || !data || !data.Content) {
 				results.push({
 					status: 3,
@@ -29,7 +32,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			try {
@@ -42,8 +45,10 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
+
+			if (includeSource) source.global.data = csvRows;
 
 			if (csvRows.length <= 2) {
 				// The only user is the root user
@@ -53,7 +58,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			for (r in csvRows) {
@@ -97,7 +102,7 @@ module.exports = {
 				});
 			}
 
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/iam/accessKeysLastUsed.js
+++ b/plugins/iam/accessKeysLastUsed.js
@@ -10,9 +10,10 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingCredentials.html',
 	recommended_action: 'Log into the IAM portal and remove the offending access key.',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 
 		var results = [];
+		var source = {};
 
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -22,6 +23,8 @@ module.exports = {
 		var iam = new AWS.IAM(LocalAWSConfig);
 
 		helpers.functions.waitForCredentialReport(iam, function(err, data){
+			if (includeSource) source.global = {error: err, data: []};
+
 			if (err || !data || !data.Content) {
 				results.push({
 					status: 3,
@@ -29,7 +32,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			try {
@@ -42,8 +45,10 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
+
+			if (includeSource) source.global.data = csvRows;
 
 			if (csvRows.length <= 2) {
 				// The only user is the root user
@@ -53,7 +58,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			for (r in csvRows) {
@@ -108,7 +113,7 @@ module.exports = {
 				});
 			}
 
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/iam/certificateExpiry.js
+++ b/plugins/iam/certificateExpiry.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/elb-update-ssl-cert.html',
 	recommended_action: 'Update your certificates before the expiration date',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -21,6 +22,8 @@ module.exports = {
 		var iam = new AWS.IAM(LocalAWSConfig);
 
 		helpers.cache(cache, iam, 'listServerCertificates', function(err, data) {
+			if (includeSource) source[region] = {error: err, data: data};
+
 			if (err || !data || !data.ServerCertificateMetadataList) {
 				results.push({
 					status: 3,
@@ -28,7 +31,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			if (!data.ServerCertificateMetadataList.length) {
@@ -38,7 +41,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			var now = new Date();
@@ -92,7 +95,7 @@ module.exports = {
 				}
 			}
 
-			return callback(null, results);
+			return callback(null, results, source);
 		});
 	}
 };

--- a/plugins/iam/emptyGroups.js
+++ b/plugins/iam/emptyGroups.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_WorkingWithGroupsAndUsers.html',
 	recommended_action: 'Remove unused groups without users',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -21,6 +22,8 @@ module.exports = {
 		var iam = new AWS.IAM(LocalAWSConfig);
 		
 		helpers.cache(cache, iam, 'listGroups', function(err, data) {
+			if (includeSource) source.global = {error: err, data: data};
+
 			if (err || !data || !data.Groups) {
 				results.push({
 					status: 3,
@@ -28,7 +31,7 @@ module.exports = {
 					region: 'global'
 				});
 				
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			if (!data.Groups.length) {
@@ -38,7 +41,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			async.eachLimit(data.Groups, 20, function(group, cb){
@@ -73,7 +76,7 @@ module.exports = {
 					cb();
 				});
 			}, function(){
-				callback(null, results);
+				callback(null, results, source);
 			});
 		});
 	}

--- a/plugins/iam/maxPasswordAge.js
+++ b/plugins/iam/maxPasswordAge.js
@@ -9,8 +9,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingPasswordPolicies.html',
 	recommended_action: 'Descrease the maximum allowed age of passwords for the password policy',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -20,6 +21,8 @@ module.exports = {
 		var iam = new AWS.IAM(LocalAWSConfig);
 
 		helpers.cache(cache, iam, 'getAccountPasswordPolicy', function(err, data) {
+			if (includeSource) source.global = {error: err, data: data};
+			
 			if (err || !data || !data.PasswordPolicy) {
 				results.push({
 					status: 3,
@@ -27,7 +30,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 			
 			if (!data.PasswordPolicy.MaxPasswordAge) {
@@ -56,7 +59,7 @@ module.exports = {
 				});
 			}
 
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/iam/minPasswordLength.js
+++ b/plugins/iam/minPasswordLength.js
@@ -9,8 +9,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingPasswordPolicies.html',
 	recommended_action: 'Increase the minimum length requirement for the password policy',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -20,6 +21,8 @@ module.exports = {
 		var iam = new AWS.IAM(LocalAWSConfig);
 
 		helpers.cache(cache, iam, 'getAccountPasswordPolicy', function(err, data) {
+			if (includeSource) source.global = {error: err, data: data};
+			
 			if (err || !data || !data.PasswordPolicy) {
 				results.push({
 					status: 3,
@@ -27,7 +30,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 			
 			if (!data.PasswordPolicy.MinimumPasswordLength) {
@@ -56,7 +59,7 @@ module.exports = {
 				});
 			}
 
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/iam/passwordExpiration.js
+++ b/plugins/iam/passwordExpiration.js
@@ -9,8 +9,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingPasswordPolicies.html',
 	recommended_action: 'Enable password expiration for the account',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -20,6 +21,8 @@ module.exports = {
 		var iam = new AWS.IAM(LocalAWSConfig);
 
 		helpers.cache(cache, iam, 'getAccountPasswordPolicy', function(err, data) {
+			if (includeSource) source.global = {error: err, data: data};
+			
 			if (err || !data || !data.PasswordPolicy) {
 				results.push({
 					status: 3,
@@ -27,7 +30,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 			
 			if (!data.PasswordPolicy.ExpirePasswords) {
@@ -56,7 +59,7 @@ module.exports = {
 				});
 			}
 
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/iam/passwordRequiresLowercase.js
+++ b/plugins/iam/passwordRequiresLowercase.js
@@ -9,8 +9,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingPasswordPolicies.html',
 	recommended_action: 'Update the password policy to require the use of lowercase letters',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -20,6 +21,8 @@ module.exports = {
 		var iam = new AWS.IAM(LocalAWSConfig);
 
 		helpers.cache(cache, iam, 'getAccountPasswordPolicy', function(err, data) {
+			if (includeSource) source.global = {error: err, data: data};
+			
 			if (err || !data || !data.PasswordPolicy) {
 				results.push({
 					status: 3,
@@ -27,7 +30,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 			
 			if (!data.PasswordPolicy.RequireLowercaseCharacters) {
@@ -44,7 +47,7 @@ module.exports = {
 				});
 			}
 
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/iam/passwordRequiresNumbers.js
+++ b/plugins/iam/passwordRequiresNumbers.js
@@ -9,8 +9,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingPasswordPolicies.html',
 	recommended_action: 'Update the password policy to require the use of numbers',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -20,6 +21,8 @@ module.exports = {
 		var iam = new AWS.IAM(LocalAWSConfig);
 
 		helpers.cache(cache, iam, 'getAccountPasswordPolicy', function(err, data) {
+			if (includeSource) source.global = {error: err, data: data};
+			
 			if (err || !data || !data.PasswordPolicy) {
 				results.push({
 					status: 3,
@@ -27,7 +30,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 			
 			if (!data.PasswordPolicy.RequireNumbers) {
@@ -44,7 +47,7 @@ module.exports = {
 				});
 			}
 
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/iam/passwordRequiresSymbols.js
+++ b/plugins/iam/passwordRequiresSymbols.js
@@ -9,8 +9,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingPasswordPolicies.html',
 	recommended_action: 'Update the password policy to require the use of symbols',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -20,6 +21,8 @@ module.exports = {
 		var iam = new AWS.IAM(LocalAWSConfig);
 
 		helpers.cache(cache, iam, 'getAccountPasswordPolicy', function(err, data) {
+			if (includeSource) source.global = {error: err, data: data};
+			
 			if (err || !data || !data.PasswordPolicy) {
 				results.push({
 					status: 3,
@@ -27,7 +30,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 			
 			if (!data.PasswordPolicy.RequireSymbols) {
@@ -44,7 +47,7 @@ module.exports = {
 				});
 			}
 
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/iam/passwordRequiresUppercase.js
+++ b/plugins/iam/passwordRequiresUppercase.js
@@ -9,8 +9,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingPasswordPolicies.html',
 	recommended_action: 'Update the password policy to require the use of uppercase letters',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -20,6 +21,8 @@ module.exports = {
 		var iam = new AWS.IAM(LocalAWSConfig);
 
 		helpers.cache(cache, iam, 'getAccountPasswordPolicy', function(err, data) {
+			if (includeSource) source.global = {error: err, data: data};
+			
 			if (err || !data || !data.PasswordPolicy) {
 				results.push({
 					status: 3,
@@ -27,7 +30,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 			
 			if (!data.PasswordPolicy.RequireUppercaseCharacters) {
@@ -44,7 +47,7 @@ module.exports = {
 				});
 			}
 
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/iam/passwordReusePrevention.js
+++ b/plugins/iam/passwordReusePrevention.js
@@ -9,8 +9,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingPasswordPolicies.html',
 	recommended_action: 'Increase the minimum previous passwors that can be reused to 24.',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -20,6 +21,8 @@ module.exports = {
 		var iam = new AWS.IAM(LocalAWSConfig);
 
 		helpers.cache(cache, iam, 'getAccountPasswordPolicy', function(err, data) {
+			if (includeSource) source.global = {error: err, data: data};
+			
 			if (err || !data || !data.PasswordPolicy) {
 				results.push({
 					status: 3,
@@ -27,7 +30,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 			
 			if (!data.PasswordPolicy.PasswordReusePrevention) {
@@ -56,7 +59,7 @@ module.exports = {
 				});
 			}
 
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/iam/rootAccessKeys.js
+++ b/plugins/iam/rootAccessKeys.js
@@ -10,9 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html',
 	recommended_action: 'Remove access keys for the root account and setup IAM users with limited permissions instead',
 
-	run: function(AWSConfig, cache, callback) {
-
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -22,6 +22,8 @@ module.exports = {
 		var iam = new AWS.IAM(LocalAWSConfig);
 
 		helpers.functions.waitForCredentialReport(iam, function(err, data){
+			if (includeSource) source.global = {error: err, data: []};
+
 			if (err || !data || !data.Content) {
 				results.push({
 					status: 3,
@@ -29,7 +31,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			try {
@@ -42,8 +44,10 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
+
+			if (includeSource) source.global.data = csvRows;
 
 			for (r in csvRows) {
 				if (r == 0) { continue; }	// Skip the header row
@@ -85,7 +89,7 @@ module.exports = {
 				});
 			}
 
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/iam/rootAccountInUse.js
+++ b/plugins/iam/rootAccountInUse.js
@@ -10,9 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/general/latest/gr/root-vs-iam.html',
 	recommended_action: 'Create IAM users with appropriate group-level permissions for account access. Create an MFA token for the root account, and store its password and token generation QR codes in a secure place.',
 
-	run: function(AWSConfig, cache, callback) {
-
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -22,6 +22,8 @@ module.exports = {
 		var iam = new AWS.IAM(LocalAWSConfig);
 
 		helpers.functions.waitForCredentialReport(iam, function(err, data){
+			if (includeSource) source.global = {error: err, data: []};
+
 			if (err || !data || !data.Content) {
 				results.push({
 					status: 3,
@@ -29,7 +31,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			try {
@@ -42,8 +44,10 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
+
+			if (includeSource) source.global.data = csvRows;
 
 			for (r in csvRows) {
 				if (r == 0) { continue; }	// Skip the header row
@@ -97,7 +101,7 @@ module.exports = {
 				});
 			}
 
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/iam/sshKeysRotated.js
+++ b/plugins/iam/sshKeysRotated.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_ssh-keys.html',
 	recommended_action: 'To rotate an SSH key, first create a new public-private key pair, then upload the public key to AWS and delete the old key.',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -21,6 +22,8 @@ module.exports = {
 		var iam = new AWS.IAM(LocalAWSConfig);
 
 		helpers.cache(cache, iam, 'listUsers', function(err, data) {
+			if (includeSource) source.global = {error: err, data: data};
+			
 			if (err || !data || !data.Users) {
 				results.push({
 					status: 3,
@@ -28,7 +31,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			if (!data.Users.length) {
@@ -38,7 +41,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			var allSSHKeys = [];
@@ -89,7 +92,7 @@ module.exports = {
 					});
 				}
 
-				callback(null, results);
+				callback(null, results, source);
 			});
 		});
 	}

--- a/plugins/iam/usersMfaEnabled.js
+++ b/plugins/iam/usersMfaEnabled.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingPasswordPolicies.html',
 	recommended_action: 'Enable an MFA device for the user account',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 		
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -21,6 +22,8 @@ module.exports = {
 		var iam = new AWS.IAM(LocalAWSConfig);
 
 		helpers.cache(cache, iam, 'listUsers', function(err, data) {
+			if (includeSource) source.global = {error: err, data: data};
+			
 			if (err || !data || !data.Users) {
 				results.push({
 					status: 3,
@@ -28,7 +31,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			if (!data.Users.length) {
@@ -38,7 +41,7 @@ module.exports = {
 					region: 'global'
 				});
 				
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			async.eachLimit(data.Users, 20, function(user, cb){
@@ -92,7 +95,7 @@ module.exports = {
 					});
 				}
 
-				callback(null, results);
+				callback(null, results, source);
 			});
 		});
 	}

--- a/plugins/kms/kmsKeyRotation.js
+++ b/plugins/kms/kmsKeyRotation.js
@@ -10,8 +10,9 @@ module.exports = {
 	recommended_action: 'Enable yearly rotation for the KMS key',
 	link: 'http://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.kms, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -21,6 +22,8 @@ module.exports = {
 			var kms = new AWS.KMS(LocalAWSConfig);
 
 			kms.listKeys({Limit: 1000}, function(listKeysErr, listKeysData){
+				if (includeSource) source.global = {error: listKeysErr, data: listKeysData};
+				
 				if (listKeysErr || !listKeysData) {
 					results.push({
 						status: 3,
@@ -96,7 +99,7 @@ module.exports = {
 				});
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/rds/rdsPubliclyAccessible.js
+++ b/plugins/rds/rdsPubliclyAccessible.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.html',
 	recommended_action: 'Remove the public endpoint from the RDS instance',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		async.eachLimit(helpers.regions.rds, helpers.MAX_REGIONS_AT_A_TIME, function(region, rcb){
 			var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
@@ -21,6 +22,8 @@ module.exports = {
 			var rds = new AWS.RDS(LocalAWSConfig);
 
 			helpers.cache(cache, rds, 'describeDBInstances', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+				
 				if (err || !data || !data.DBInstances) {
 					results.push({
 						status: 3,
@@ -65,7 +68,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/route53/domainAutoRenew.js
+++ b/plugins/route53/domainAutoRenew.js
@@ -9,8 +9,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/Route53/latest/APIReference/api-enable-domain-auto-renew.html',
 	recommended_action: 'Enable auto renew for the domain',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -20,6 +21,8 @@ module.exports = {
 		var route53domains = new AWS.Route53Domains(LocalAWSConfig);
 
 		helpers.cache(cache, route53domains, 'listDomains', function(err, data) {
+			if (includeSource) source.global = {error: err, data: data};
+
 			if (err || !data || !data.Domains) {
 				results.push({
 					status: 3,
@@ -27,7 +30,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			if (!data.Domains.length) {
@@ -37,7 +40,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			for (i in data.Domains) {
@@ -59,7 +62,7 @@ module.exports = {
 				}
 			}
 
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/route53/domainExpiry.js
+++ b/plugins/route53/domainExpiry.js
@@ -9,8 +9,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/registrar.html',
 	recommended_action: 'Reregister the expiring domain',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -20,6 +21,8 @@ module.exports = {
 		var route53domains = new AWS.Route53Domains(LocalAWSConfig);
 
 		helpers.cache(cache, route53domains, 'listDomains', function(err, data) {
+			if (includeSource) source.global = {error: err, data: data};
+			
 			if (err || !data || !data.Domains) {
 				results.push({
 					status: 3,
@@ -27,7 +30,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			if (!data.Domains.length) {
@@ -37,7 +40,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			for (i in data.Domains) {
@@ -84,7 +87,7 @@ module.exports = {
 				}
 			}
 
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/route53/domainTransferLock.js
+++ b/plugins/route53/domainTransferLock.js
@@ -9,8 +9,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/domain-transfer-from-route-53.html',
 	recommended_action: 'Enable the transfer lock for the domain',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		var LocalAWSConfig = JSON.parse(JSON.stringify(AWSConfig));
 
@@ -20,6 +21,8 @@ module.exports = {
 		var route53domains = new AWS.Route53Domains(LocalAWSConfig);
 
 		helpers.cache(cache, route53domains, 'listDomains', function(err, data) {
+			if (includeSource) source.global = {error: err, data: data};
+			
 			if (err || !data || !data.Domains) {
 				results.push({
 					status: 3,
@@ -27,7 +30,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			if (!data.Domains.length) {
@@ -37,7 +40,7 @@ module.exports = {
 					region: 'global'
 				});
 
-				return callback(null, results);
+				return callback(null, results, source);
 			}
 
 			for (i in data.Domains) {
@@ -59,7 +62,7 @@ module.exports = {
 				}
 			}
 
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };

--- a/plugins/vpc/classicInstances.js
+++ b/plugins/vpc/classicInstances.js
@@ -10,8 +10,9 @@ module.exports = {
 	link: 'http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Introduction.html',
 	recommended_action: 'Migrate instances from EC2 Classic to VPC',
 
-	run: function(AWSConfig, cache, callback) {
+	run: function(AWSConfig, cache, includeSource, callback) {
 		var results = [];
+		var source = {};
 
 		var params = {
 			Filters: [
@@ -36,6 +37,8 @@ module.exports = {
 			var ec2 = new AWS.EC2(LocalAWSConfig);
 
 			helpers.cache(cache, ec2, 'describeInstances', function(err, data) {
+				if (includeSource) source[region] = {error: err, data: data};
+				
 				if (err || !data || !data.Reservations) {
 					results.push({
 						status: 3,
@@ -95,7 +98,7 @@ module.exports = {
 				rcb();
 			});
 		}, function(){
-			callback(null, results);
+			callback(null, results, source);
 		});
 	}
 };


### PR DESCRIPTION
This PR adds an `includeSource` param to the `run` command for each plugin. When set to `true`, the callback containing the results will include a third param containing an object which contains the error and data responses from AWS. This is useful for debugging and seeing the original API responses.