### PR TITLE
Fix for VPC classicInstances Plugin Showing Terminated Instances

### DIFF
--- a/plugins/vpc/classicInstances.js
+++ b/plugins/vpc/classicInstances.js
@@ -36,7 +36,7 @@ module.exports = {
 			LocalAWSConfig.region = region;
 			var ec2 = new AWS.EC2(LocalAWSConfig);
 
-			helpers.cache(cache, ec2, 'describeInstances', function(err, data) {
+			ec2.describeInstances(params, function(err, data){
 				if (includeSource) source[region] = {error: err, data: data};
 				
 				if (err || !data || !data.Reservations) {


### PR DESCRIPTION
This PR fixes a bug causing the plugin to show terminated instances because the filter parameters were not being passed to the cache function.