### PR TITLE
Bugfix: Check Default Certificate for CloudFront Insecure Protocols Check

### DIFF
--- a/plugins/cloudfront/insecureProtocols.js
+++ b/plugins/cloudfront/insecureProtocols.js
@@ -38,7 +38,12 @@ module.exports = {
 				return cb();
 			}
 
-			if (distribution.ViewerCertificate.MinimumProtocolVersion === 'SSLv3') {
+			// Treat the default certificate as secure
+			// IAM/ACM certificates should be analyzed for protocol version
+			if (distribution.ViewerCertificate.CloudFrontDefaultCertificate) {
+				helpers.addResult(results, 0, 'Distribution is using secure default certificate',
+						'global', distribution.ARN);
+			} else if (distribution.ViewerCertificate.MinimumProtocolVersion === 'SSLv3') {
 				helpers.addResult(results, 1, 'Distribution is using insecure SSLv3',
 						'global', distribution.ARN);
 			} else {


### PR DESCRIPTION
Based on user feedback and conversations with AWS, the default certificate provided by CloudFront _is_ using TLS, despite returning `SSLv3` in the SDK response. Whether this is due to a bug in AWS SDK or misguided documentation (AWS has mentioned both scenarios) remains to be seen. However, this update forces the default certificate to be treated as secure. Until we have further guidance, we're continuing to check the protocol of the IAM and ACM certificates, which users _do_ control.