### PR TITLE
Adds subnetIpAvailability to ec2 plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ npm install
 ## Setup
 To begin using the scanner, edit the `index.js` file with your AWS key, secret, and optionally (for temporary credentials), a session token. You can also set a file containing credentials. To determine the permissions associated with your credentials, see the [permissions section below](#permissions). In the list of plugins in the `exports.js` file, comment out any plugins you do not wish to run. You can also skip entire regions by modifying the `skipRegions` array.
 
+You can also set the typical environment variables expected by the aws sdks, namely `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`.
+
 ### Cross Account Roles
 When using the [hosted scanner](https://cloudsploit.com/scan), you'll need to create a cross-account IAM role. Cross-account roles enable you to share access to your account with another AWS account using the same policy model that you're used to. The advantage is that cross-account roles are much more secure than key-based access, since an attacker who steals a cross-account role ARN still can't make API calls unless they also infiltrate the authorized AWS account.
 

--- a/collect.js
+++ b/collect.js
@@ -66,6 +66,9 @@ var calls = {
 		describeAccountAttributes: {
 			property: 'AccountAttributes'
 		},
+		describeSubnets: {
+			property: 'Subnets'
+		},
 		describeAddresses: {
 			property: 'Addresses'
 		},
@@ -181,6 +184,11 @@ var calls = {
 	SNS: {
 		listTopics: {
 			property: 'Topics'
+		}
+	},
+	STS: {
+		getCallerIdentity: {
+			property: 'Account'
 		}
 	}
 };
@@ -334,7 +342,7 @@ var collect = function(AWSConfig, settings, callback) {
 						if (err) {
 							collection[serviceLower][callKey][region].err = err;
 						}
-						
+
 						// TODO: pagination
 						// TODO: handle s3 region fixes (possibly use an override)
 						if (!data) return regionCb();
@@ -361,7 +369,7 @@ var collect = function(AWSConfig, settings, callback) {
 					} else {
 						executor[callKey](executorCb);
 					}
-					
+
 				}
 			}, function(){
 				callCb();
@@ -379,7 +387,7 @@ var collect = function(AWSConfig, settings, callback) {
 				async.eachOfLimit(serviceObj, 1, function(callObj, callKey, callCb){
 					if (settings.api_calls && settings.api_calls.indexOf(service + ':' + callKey) === -1) return callCb();
 					if (!collection[serviceLower][callKey]) collection[serviceLower][callKey] = {};
-					
+
 					async.eachLimit(helpers.regions[serviceLower], helpers.MAX_REGIONS_AT_A_TIME, function(region, regionCb){
 						if (settings.skip_regions &&
 							settings.skip_regions.indexOf(region) > -1 &&

--- a/exports.js
+++ b/exports.js
@@ -21,6 +21,7 @@ module.exports = {
 
     'defaultSecurityGroup'          : require(__dirname + '/plugins/ec2/defaultSecurityGroup.js'),
     'elasticIpLimit'                : require(__dirname + '/plugins/ec2/elasticIpLimit.js'),
+    'subnetIpAvailability'          : require(__dirname + '/plugins/ec2/subnetIpAvailability.js'),
     'excessiveSecurityGroups'       : require(__dirname + '/plugins/ec2/excessiveSecurityGroups.js'),
     'instanceLimit'                 : require(__dirname + '/plugins/ec2/instanceLimit.js'),
     'openAllPortsProtocols'         : require(__dirname + '/plugins/ec2/openAllPortsProtocols.js'),

--- a/helpers/functions.js
+++ b/helpers/functions.js
@@ -84,7 +84,7 @@ function addSource(cache, source, paths){
 		var original = (cache[service] &&
 					   cache[service][call] &&
 					   cache[service][call][region] &&
-					   cache[service][call][region][extra]) ? 
+					   cache[service][call][region][extra]) ?
 					   cache[service][call][region][extra] : null;
 
 		source[service][call][region][extra] = original;
@@ -101,7 +101,7 @@ function addSource(cache, source, paths){
 }
 
 function findOpenPorts(groups, ports, service, region, results) {
-	var found = false;	
+	var found = false;
 
 	for (g in groups) {
 		var strings = [];
@@ -189,8 +189,18 @@ function isCustom(providedSettings, pluginSettings) {
 	return isCustom;
 }
 
+function cidrSize(block){
+	/*
+	Determine the number of IP addresses in a given CIDR block
+	Algorithm from https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation
+	2^(address length - prefix length)
+	*/
+	return Math.pow(2, 32 - block.split('/')[1]);
+}
+
 module.exports = {
 	daysBetween: daysBetween,
+	cidrSize: cidrSize,
 	daysAgo: daysAgo,
 	mostRecentDate: mostRecentDate,
 	addResult: addResult,

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -5,6 +5,7 @@ module.exports = {
 	addSource: require('./functions.js').addSource,
 	addError: require('./functions.js').addError,
 	isCustom: require('./functions.js').isCustom,
+	cidrSize: require('./functions.js').cidrSize,
 	findOpenPorts: require('./functions.js').findOpenPorts,
 
 	MAX_REGIONS_AT_A_TIME: 6

--- a/helpers/regions.js
+++ b/helpers/regions.js
@@ -51,6 +51,7 @@ module.exports = {
 		'us-east-1', 'us-west-2',
 		'eu-west-1'],
 	sns: regions,
+	sts: ['us-east-1'],
 	lambda: ['us-east-1', 'us-east-2', 'us-west-1', 'us-west-2',
 			 'eu-west-1', 'eu-central-1', 'eu-west-2', 'ap-southeast-1',
 			 'ap-southeast-2', 'ap-northeast-1', 'ap-northeast-2',

--- a/index.js
+++ b/index.js
@@ -15,6 +15,16 @@ var AWSConfig;
 // OPTION 2: Import an AWS config file containing credentials
 // AWSConfig = require(__dirname + '/credentials.json');
 
+// OPTION 3: ENV configuration with AWS_ env vars
+if(process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY){
+    AWSConfig = {
+        accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+        secretAccessKey:  process.env.AWS_SECRET_ACCESS_KEY,
+        sessionToken: process.env.AWS_SESSION_TOKEN,
+        region: process.env.AWS_DEFAULT_REGION || 'us-east-1'
+    };
+}
+
 if (!AWSConfig || !AWSConfig.accessKeyId) {
     return console.log('ERROR: Invalid AWSConfig');
 }
@@ -60,7 +70,7 @@ collector(AWSConfig, {api_calls: apiCalls, skip_regions: skipRegions}, function(
                 } else {
                     statusWord = 'UNKNOWN';
                 }
-                
+
                 console.log(plugin.category + '\t' + plugin.title + '\t' +
                             (results[r].resource || 'N/A') + '\t' +
                             (results[r].region || 'Global') + '\t\t' +

--- a/plugins/ec2/subnetIpAvailability.js
+++ b/plugins/ec2/subnetIpAvailability.js
@@ -1,0 +1,79 @@
+var async = require('async');
+var helpers = require('../../helpers');
+
+module.exports = {
+	title: 'Subnet IP Availability',
+	category: 'EC2',
+	description: 'Determine if a subnet is at risk of running out of IP addresses',
+	more_info: 'Subnets have finite IP addresses. Running out of IP addresses could prevent resources from launching.',
+	recommended_action: 'Add a new subnet with larger CIDR block and migrate resources.',
+	link: 'http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Subnets.html',
+	apis: ['EC2:describeSubnets', 'STS:getCallerIdentity'],
+	settings: {
+		subnet_ip_availability_percentage_fail: {
+			name: 'Subnet IP Availability Percentage Fail',
+			description: 'Return a failing result when consumed subnet IPs equals or exceeds this percentage',
+			regex: '^(100|[1-9][0-9]?)$',
+			default: 90
+		},
+		subnet_ip_availability_percentage_warn: {
+			name: 'Subnet IP Availability Percentage Warn',
+			description: 'Return a warning result when consumed subnet IPs equals or exceeds this percentage',
+			regex: '^(100|[1-9][0-9]?)$',
+			default: 75
+		}
+	},
+
+	run: function(cache, settings, callback) {
+		var config = {
+			subnet_ip_availability_percentage_fail: settings.subnet_ip_availability_percentage_fail || this.settings.subnet_ip_availability_percentage_fail.default,
+			subnet_ip_availability_percentage_warn: settings.subnet_ip_availability_percentage_warn || this.settings.subnet_ip_availability_percentage_warn.default
+		};
+
+		var custom = helpers.isCustom(settings, this.settings);
+
+		var results = [];
+		var source = {};
+		var accountId = helpers.addSource(cache, source, ['sts', 'getCallerIdentity', 'us-east-1', 'data']);
+
+		async.each(helpers.regions.ec2, function(region, rcb){
+			var describeSubnets = helpers.addSource(cache, source,
+				['ec2', 'describeSubnets', region]);
+
+			if (!describeSubnets) return rcb();
+
+			if (describeSubnets.err || !describeSubnets.data) {
+				helpers.addResult(results, 3,
+					'Unable to query for subnets: ' + helpers.addError(describeSubnets), region);
+				return rcb();
+            }
+
+            if (!describeSubnets.data.length) {
+				helpers.addResult(results, 0, 'No subnets found', region);
+				return rcb();
+			}
+
+            for(i in describeSubnets.data){
+                var subnetSize = helpers.cidrSize(describeSubnets.data[i].CidrBlock);
+				var consumedIPs = subnetSize - describeSubnets.data[i].AvailableIpAddressCount
+				var percentageConsumed = Math.ceil((consumedIPs / subnetSize) * 100);
+				var subnetArn = 'arn:aws:ec2:' + region + ':' + accountId + ':subnet/' + describeSubnets.data[i].SubnetId;
+
+                returnMsg = 'Subnet ' + describeSubnets.data[i].SubnetId
+                            + ' is using ' + consumedIPs + ' of '
+                            + subnetSize + ' (' + percentageConsumed + '%) available IPs.';
+
+                if (percentageConsumed >= config.subnet_ip_availability_percentage_fail) {
+                    helpers.addResult(results, 2, returnMsg, region, subnetArn, custom);
+                } else if (percentageConsumed >= config.subnet_ip_availability_percentage_warn) {
+                    helpers.addResult(results, 1, returnMsg, region, subnetArn, custom);
+                } else {
+                    helpers.addResult(results, 0, returnMsg, region, subnetArn, custom);
+                }
+			}
+			rcb();
+		}, function(){
+			callback(null, results, source);
+		});
+	}
+};


### PR DESCRIPTION
This computes the size of a subnet, and makes sure we haven't breached thresholds for warn and failure based on the percentage of consumed space.

Also note, this adds a collector for the `STS.getCallerIdentity` to fetch the account id. This call requires no IAM permissions beyond having a user or role credentials and allows you to grab the AWS account id to construct resource arns arbitrarily.