### PR TITLE
Update rdsMultiAz and rdsRestorable to support Aurora Postgres

### DIFF
--- a/plugins/rds/rdsMultiAz.js
+++ b/plugins/rds/rdsMultiAz.js
@@ -33,7 +33,7 @@ module.exports = {
 
             // loop through Rds Instances
             describeDBInstances.data.forEach(function(Rds){
-                if (Rds.Engine === 'aurora') {
+                if (Rds.Engine === 'aurora' || Rds.Engine === 'aurora-postgresql') {
                     helpers.addResult(results, 0,
                         'RDS Aurora instances are multi-AZ',
                         region, Rds.DBInstanceArn);

--- a/plugins/rds/rdsRestorable.js
+++ b/plugins/rds/rdsRestorable.js
@@ -58,7 +58,7 @@ module.exports = {
 				var db = describeDBInstances.data[i];
 
 				// Aurora databases do not list the restore information in this API call
-				if (db.Engine && db.Engine === 'aurora') {
+				if (db.Engine && (db.Engine === 'aurora' || db.Engine === 'aurora-postgresql')) {
 					clustersPresent = true;
 					continue;
 				}


### PR DESCRIPTION
Aurora Postgres has the same exceptional qualities as Aurora MySQL
for the purposes of the `MultiAz` and `Restorable` plugins. Those
plugins have short circuit conditionals for the `aurora` engine,
but Aurora Postgres presents as `aurora-postgresql`. So let's add
that to the conditional.