### PR TITLE
Fix "Maximum call stack size exceeded" error

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ collector(AWSConfig, {api_calls: apiCalls, skip_regions: skipRegions}, function(
                             statusWord + '\t' + results[r].message);
             }
 
-            callback(err);
+            setTimeout(function() { callback(err); }, 0);
         });
     }, function(err){
         if (err) return console.log(err);


### PR DESCRIPTION
Running cloudsploit/scans master (c11a6fd49d59150caa5e4f7af240be353360217a) against a large AWS account, I consistently encounter this error:

```
node ./cloudsploit/index.js

./cloudsploit/node_modules/aws-sdk/lib/request.js:31
            throw err;
            ^

RangeError: Maximum call stack size exceeded
    at ./cloudsploit/node_modules/async/dist/async.js:3339:20
    at replenish (./cloudsploit/node_modules/async/dist/async.js:836:21)
    at ./cloudsploit/node_modules/async/dist/async.js:846:15
    at eachLimit (./cloudsploit/node_modules/async/dist/async.js:3344:35)
    at Object.<anonymous> (./cloudsploit/node_modules/async/dist/async.js:874:20)
    at Object.run (./cloudsploit/plugins/rds/rdsAutomatedBackups.js:31:9)
    at ./cloudsploit/index.js:85:16
    at replenish (./cloudsploit/node_modules/async/dist/async.js:836:21)
    at ./cloudsploit/node_modules/async/dist/async.js:842:29
    at ./cloudsploit/node_modules/async/dist/async.js:804:16
```

Searching around a bit, it seems to fit the description in this async issue: https://github.com/caolan/async/issues/75. The recommendation there is to make sure you're using async asynchronously. With that in mind, this patch seems to fix things for me.

I don't know async or Cloudsploit well, so I don't know whether this is the best place for this fix, but I can run the scan without error now.