### PR TITLE
KMS Region Support for SQS Encryption

### DIFF
--- a/plugins/sqs/sqsEncrypted.js
+++ b/plugins/sqs/sqsEncrypted.js
@@ -3,7 +3,7 @@ var helpers = require('../../helpers');
 
 // SSE via KMS is only supported in some regions
 // even though SQS is supported in all regions.
-var supportedRegions = ['us-east-1', 'us-east-2', 'us-west-2'];
+var supportedRegions = ['us-east-1', 'us-east-2', 'us-west-2', 'us-west-1', 'ca-central-1', 'eu-central-1', 'eu-west-1', 'eu-west-2','eu-west-3','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-southeast-1','ap-southeast-2','ap-south-1','sa-east-1'];
 var defaultKmsKey = 'alias/aws/sqs';
 
 module.exports = {


### PR DESCRIPTION
KMS is now available in all regions except China regions.  Updated the supported regions to add all other regions to this plugin.