### PR TITLE
Updated CF Cipher

### DIFF
--- a/plugins/cloudfront/insecureProtocols.js
+++ b/plugins/cloudfront/insecureProtocols.js
@@ -51,11 +51,19 @@ module.exports = {
 			} else if (distribution.ViewerCertificate.MinimumProtocolVersion === 'SSLv3') {
 				helpers.addResult(results, 1, 'Distribution is using insecure SSLv3',
 						'global', distribution.ARN);
+            } else if {distribution.ViewerCertificate.MinimumProtocolVersion === 'TLSv1') {
+            	helpers.addResult(results, 1, 'Distribution is using insecure TLSv1.0',
+                		'global', distribution.ARN);
+        	} else if {distribution.ViewerCertificate.MinimumProtocolVersion === 'TLSv1_2016') {
+    			helpers.addResult(results, 1, 'Distribution is using insecure TLSv1_2016',
+        				'global', distribution.ARN);
+			} else if {distribution.ViewerCertificate.MinimumProtocolVersion === 'TLSv1.1_2016') {
+    			helpers.addResult(results, 0, 'Distribution is using secure TLSv1.1_2016',
+        				'global', distribution.ARN);
 			} else {
-				helpers.addResult(results, 0, 'Distribution is using secure TLSv1',
-						'global', distribution.ARN);
-			}
-
+    			helpers.addResult(results, 0, 'Distribution is using secure TLSv1.2_2018',
+        				'global', distribution.ARN);
+}
 			cb();
 		}, function(){
 			callback(null, results, source);


### PR DESCRIPTION
Marked TLS 1 as insecure and added 1.1 and 1.2 ciphers

Ref https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html

"We recommend that you specify TLSv1.1_2016 unless your users are using browsers or devices that don't support TLSv1.1 or later."