### PR TITLE
Hotfixes/filter out aws spot instances ec2 instancelimit 420

### DIFF
--- a/plugins/ec2/instanceLimit.js
+++ b/plugins/ec2/instanceLimit.js
@@ -69,14 +69,28 @@ module.exports = {
 					'Unable to query for instances: ' + helpers.addError(describeInstances), region);
 				return rcb();
 			}
-			
+
+			var ec2Instances = 0;
+			var spotInstances = 0;
+
 			if (!describeInstances.data.length) {
 				helpers.addResult(results, 0, 'No instances found', region);
 				return rcb();
+			} else {
+				for (instances in describeInstances.data){
+					for (instance in describeInstances.data[instances].Instances){
+						if (describeInstances.data[instances].Instances[instance].SpotInstanceRequestId){
+							spotInstances=+1;
+						} else {
+							ec2Instances=+1;
+						}
+
+					}
+				}
 			}
 
-			var percentage = Math.ceil((describeInstances.data.length / limits['max-instances'])*100);
-			var returnMsg = 'Account contains ' + describeInstances.data.length + ' of ' + limits['max-instances'] + ' (' + percentage + '%) available instances';
+			var percentage = Math.ceil((ec2Instances / limits['max-instances'])*100);
+			var returnMsg = 'Account contains ' + ec2Instances + ' of ' + limits['max-instances'] + ' (' + percentage + '%) available instances';
 
 			if (percentage >= config.instance_limit_percentage_fail) {
 				helpers.addResult(results, 2, returnMsg, region, null, custom);

--- a/plugins/ec2/instanceLimit.js
+++ b/plugins/ec2/instanceLimit.js
@@ -80,9 +80,9 @@ module.exports = {
 				for (instances in describeInstances.data){
 					for (instance in describeInstances.data[instances].Instances){
 						if (describeInstances.data[instances].Instances[instance].SpotInstanceRequestId){
-							spotInstances=+1;
+							spotInstances+=1;
 						} else {
-							ec2Instances=+1;
+							ec2Instances+=1;
 						}
 
 					}


### PR DESCRIPTION
Ignoring spot instances for the final instance count. Spot instances are being counted but not used 