### PR TITLE
EC2 Snapshots: Fix bug on collecting EC2 Snapshots

### DIFF
--- a/collectors/aws/ec2/describeSnapshots.js
+++ b/collectors/aws/ec2/describeSnapshots.js
@@ -34,9 +34,10 @@ module.exports = function(AWSConfig, collection, callback) {
 		ec2.describeSnapshots(params, function(err, data){
 			if (err) {
 			    collection.ec2.describeSnapshots[AWSConfig.region].err = err;
+			} else {
+				collection.ec2.describeSnapshots[AWSConfig.region].data = data.Snapshots;
 			}
-			collection.ec2.describeSnapshots[AWSConfig.region].data = data.Snapshots;
-			
+
 			callback();
 		});
 	});


### PR DESCRIPTION
When data is null (i.e., an error is returned), data does not have an property 'Snapshots'. This fix prevents a TypeError from throwing. 