### PR TITLE
Prevent Some Database Engines from Failing "RDS Logging Enabled"

### DIFF
--- a/collectors/aws/collector.js
+++ b/collectors/aws/collector.js
@@ -261,6 +261,9 @@ var calls = {
 		},
 		describeDBClusters: {
 			property: 'DBClusters'
+		},
+		describeDBEngineVersions: {
+			property: 'DBEngineVersions'
 		}
 	},
 	Redshift: {

--- a/plugins/aws/rds/rdsLoggingEnabled.js
+++ b/plugins/aws/rds/rdsLoggingEnabled.js
@@ -8,44 +8,63 @@ module.exports = {
 	more_info: 'Logging database level events enables teams to analyze events for the purpose diagnostics as well as audit tracking for compliance purposes.',
 	link: 'https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html',
 	recommended_action: 'Modify the RDS instance to enable logging as required.',
-	apis: ['RDS:describeDBInstances'],
+	apis: ['RDS:describeDBInstances', 'RDS:describeDBEngineVersions'],
 
 	run: function(cache, settings, callback) {
 		var results = [];
 		var source = {};
 		var regions = helpers.regions(settings.govcloud);
 
-		async.each(regions.rds, function(region, rcb){
+		async.each(regions.rds, function(region, rcb) {
 			var describeDBInstances = helpers.addSource(cache, source,
 				['rds', 'describeDBInstances', region]);
-
 			if (!describeDBInstances) return rcb();
-
 			if (describeDBInstances.err || !describeDBInstances.data) {
 				helpers.addResult(results, 3,
 					'Unable to query for RDS instances: ' + helpers.addError(describeDBInstances), region);
 				return rcb();
 			}
-
 			if (!describeDBInstances.data.length) {
 				helpers.addResult(results, 0, 'No RDS instances found', region);
 				return rcb();
 			}
+
+			var describeDBEngineVersions = helpers.addSource(cache, source,
+				['rds', 'describeDBEngineVersions', region]);
+			if (!describeDBEngineVersions) return rcb();
+			if (describeDBEngineVersions.err || !describeDBEngineVersions.data) {
+				helpers.addResult(results, 3,
+					'Unable to query for RDS engine versions: ' + helpers.addError(describeDBEngineVersions), region);
+				return rcb();
+			}
+			
+			var eligibleDBEngineVersions = describeDBEngineVersions.data.filter(function(dbEngine) {
+				return dbEngine.SupportsLogExportsToCloudwatchLogs;
+			});
+
 			for (i in describeDBInstances.data) {
 				// For resource, attempt to use the endpoint address (more specific) but fallback to the instance identifier
 				var db = describeDBInstances.data[i];
 				var dbResource = db.DBInstanceArn;
-				console.log(db.EnabledCloudwatchLogsExports);
 
 				if (db.EnabledCloudwatchLogsExports && db.EnabledCloudwatchLogsExports.length) {
 					helpers.addResult(results, 0, 'Logging is enabled', region, dbResource);
 				} else {
-					helpers.addResult(results, 2, 'Logging is not enabled', region, dbResource);
+					// If logging is not enabled, see if it *can* be enabled.
+					var matchingDBEngineVersions = eligibleDBEngineVersions.filter(function(dbEngine) {
+						return dbEngine.Engine === db.Engine && dbEngine.EngineVersion === db.EngineVersion;
+					});
+					if (matchingDBEngineVersions.length)
+					{
+						helpers.addResult(results, 2, 'Logging is not enabled', region, dbResource);
+					} else {
+						helpers.addResult(results, 0, 'Logging is not enabled, but cannot be enabled', region, dbResource);
+					}
 				}
 			}
 			
 			rcb();
-		}, function(){
+		}, function() {
 			callback(null, results, source);
 		});
 	}


### PR DESCRIPTION
Not all database engines can have CloudWatch logging
enabled. Fortunately, AWS has a property for this, and we can check
for it in the test.

This avoids false negatives for database engines such as Aurora
PostgreSQL, SQL Server Express, &c.

Fixes: #181