### PR TITLE
fix executable name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,5 @@ ENV PATH "$PATH:/var/scan/node_modules/.bin"
 # command line arguments to the run command to control how this executes.
 # Thus, you can use the parameters that you would normally give to index.js
 # when running in a container.
-ENTRYPOINT ["cloudsploit-scan"]
+ENTRYPOINT ["cloudsploitscan"]
 CMD []


### PR DESCRIPTION
The executable name is `cloudsploitscan`, not `cloudsploit-scan`