### PR TITLE
Adds cloudtrail bucket regex setting to ignore certain buckets

### DIFF
--- a/plugins/aws/cloudtrail/cloudtrailBucketPrivate.js
+++ b/plugins/aws/cloudtrail/cloudtrailBucketPrivate.js
@@ -14,7 +14,7 @@ module.exports = {
             name: 'CloudTrail Bucket Regex',
             description: 'Ignore if the cloudtrail bucket matches this regex',
             regex: '^.*$',
-            default: null
+            default: '^$',
         },
     },
 
@@ -22,6 +22,13 @@ module.exports = {
         var results = [];
         var source = {};
         var regions = helpers.regions(settings);
+
+        var bucketRegex = RegExp(this.settings.cloudtrail_bucket_regex.default);
+        try {
+            var bucketRegex = RegExp(settings.cloudtrail_bucket_regex || this.settings.cloudtrail_bucket_regex.default);
+        } catch (err) {
+            helpers.addResult(results, 3, err.message, 'global', this.settings.cloudtrail_bucket_regex.name);
+        }
 
         async.each(regions.cloudtrail, function(region, rcb){
 
@@ -42,7 +49,7 @@ module.exports = {
             }
 
             async.each(describeTrails.data, function(trail, cb){
-                if (!trail.S3BucketName || RegExp(settings.cloudtrail_bucket_regex).test(trail.S3BucketName))
+                if (!trail.S3BucketName || bucketRegex.test(trail.S3BucketName))
                     return cb();
                 var s3Region = helpers.defaultRegion(settings);
 

--- a/plugins/aws/cloudtrail/cloudtrailBucketPrivate.js
+++ b/plugins/aws/cloudtrail/cloudtrailBucketPrivate.js
@@ -10,10 +10,10 @@ module.exports = {
     link: 'http://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html',
     apis: ['CloudTrail:describeTrails', 'S3:getBucketAcl'],
     settings: {
-        cloudtrail_bucket_whitelist: {
-            name: 'CloudTrail Bucket Whitelist',
-            description: 'Return a passing result if the cloudtrail bucket has this string',
-            regex: '^(?=^.{3,63}$)(?!^(\d+\.)+\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$)$',
+        cloudtrail_bucket_regex: {
+            name: 'CloudTrail Bucket Regex',
+            description: 'Ignore if the cloudtrail bucket matches this regex',
+            regex: '^.*$',
             default: null
         },
     },
@@ -42,7 +42,7 @@ module.exports = {
             }
 
             async.each(describeTrails.data, function(trail, cb){
-                if (!trail.S3BucketName || settings.cloudtrail_bucket_whitelist.find(trail.S3BucketName.includes))
+                if (!trail.S3BucketName || RegExp(settings.cloudtrail_bucket_regex).test(trail.S3BucketName))
                     return cb();
                 var s3Region = helpers.defaultRegion(settings);
 

--- a/plugins/aws/cloudtrail/cloudtrailBucketPrivate.js
+++ b/plugins/aws/cloudtrail/cloudtrailBucketPrivate.js
@@ -9,6 +9,14 @@ module.exports = {
     recommended_action: 'Set the S3 bucket access policy for all CloudTrail buckets to only allow known users to access its files.',
     link: 'http://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html',
     apis: ['CloudTrail:describeTrails', 'S3:getBucketAcl'],
+    settings: {
+        cloudtrail_bucket_whitelist: {
+            name: 'CloudTrail Bucket Whitelist',
+            description: 'Return a passing result if the cloudtrail bucket has this string',
+            regex: '^(?=^.{3,63}$)(?!^(\d+\.)+\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$)$',
+            default: null
+        },
+    },
 
     run: function(cache, settings, callback) {
         var results = [];
@@ -34,8 +42,8 @@ module.exports = {
             }
 
             async.each(describeTrails.data, function(trail, cb){
-                if (!trail.S3BucketName) return cb();
-
+                if (!trail.S3BucketName || settings.cloudtrail_bucket_whitelist.find(trail.S3BucketName.includes))
+                    return cb();
                 var s3Region = helpers.defaultRegion(settings);
 
                 var getBucketAcl = helpers.addSource(cache, source,


### PR DESCRIPTION
Adds a setting to the `cloudtrailBucketPrivate` plugin that will be treated as a regex for which cloudtrail buckets to ignore.

There is one concern I have
- How should an invalid setting input be handled? As it is, if someone puts an invalid regex (like `(`), the plugin will throw an error. I see there's validation that happens when a setting is input, but it'd be difficult to create a stable [regex for a regex](https://stackoverflow.com/a/55575718). Very open to thoughts and feedback.