### PR TITLE
rate limit lambda get policy

### DIFF
--- a/collectors/aws/collector.js
+++ b/collectors/aws/collector.js
@@ -666,7 +666,8 @@ var postcalls = [
                 reliesOnService: 'lambda',
                 reliesOnCall: 'listFunctions',
                 filterKey: 'FunctionName',
-                filterValue: 'FunctionName'
+                filterValue: 'FunctionName',
+                rateLimit: 100, // it's not documented but experimentially 10/second works.
             },
             listTags: {
                 reliesOnService: 'lambda',


### PR DESCRIPTION
Implements rate limiting on AWS Lambda collection

These plugins were developed by Trek10 under contract to WarnerMedia for release back into the main CloudSploit Scanning Engine. WarnerMedia expressly authorizes their contribution. 