### PR TITLE
Feature/plugin/iam user admins

### DIFF
--- a/plugins/aws/iam/iamUserAdmins.js
+++ b/plugins/aws/iam/iamUserAdmins.js
@@ -20,17 +20,24 @@ module.exports = {
              'reduces the scope of users with potential access to this data.'
     },
     settings: {
-        iam_admin_count: {
-            name: 'IAM Admin Count',
-            description: 'The number of IAM user admins to require in the account',
+        iam_admin_count_minimum: {
+            name: 'IAM Admin Count Minimum',
+            description: 'The minimum number of IAM user admins to require in the account',
             regex: '^[1-9]{1}[0-9]{0,3}$',
-            default: 2
+            default: 1
+        },
+        iam_admin_count_maximum: {
+            name: 'IAM Admin Count Maximum',
+            description: 'The maximum number of IAM user admins to require in the account',
+            regex: '^[1-9]{1}[0-9]{0,3}$',
+            default: 9
         }
     },
 
     run: function(cache, settings, callback) {
         var config = {
-            iam_admin_count: settings.iam_admin_count || this.settings.iam_admin_count.default
+            iam_admin_count_minimum: settings.iam_admin_count_minimum || this.settings.iam_admin_count_minimum.default,
+            iam_admin_count_maximum: settings.iam_admin_count_maximum || this.settings.iam_admin_count_maximum
         };
 
         var custom = helpers.isCustom(settings, this.settings);
@@ -212,18 +219,18 @@ module.exports = {
             cb();
         }, function(){
             // Use admins array
-            if (userAdmins.length < config.iam_admin_count) {
+            if (userAdmins.length < config.iam_admin_count_minimum) {
                 helpers.addResult(results, 1,
-                    'There are fewer than ' + config.iam_admin_count + ' IAM user administrators',
+                    'There are fewer than the minimum ' + config.iam_admin_count_minimum + ' IAM user administrators',
                     'global', null, custom);
-            } else if (userAdmins.length == config.iam_admin_count) {
+            } else if (userAdmins.length >= config.iam_admin_count_minimum && userAdmins.length <= config.iam_admin_count_maximum) {
                 helpers.addResult(results, 0,
-                    'There are ' + config.iam_admin_count + ' IAM user administrators',
+                    'There are ' + userAdmins.length + ' IAM user administrators',
                     'global', null, custom);
             } else {
                 for (u in userAdmins) {
                     helpers.addResult(results, 2,
-                        'User: ' + userAdmins[u].name + ' is one of ' + userAdmins.length + ' IAM user administrators, which exceeds the expected value of: ' + config.iam_admin_count,
+                        'User: ' + userAdmins[u].name + ' is one of ' + userAdmins.length + ' IAM user administrators, which exceeds the expected value of: ' + config.iam_admin_count_maximum,
                         'global', userAdmins[u].arn, custom);
                 }
             }

--- a/plugins/aws/iam/iamUserAdmins.js
+++ b/plugins/aws/iam/iamUserAdmins.js
@@ -23,28 +23,32 @@ module.exports = {
         iam_admin_count_minimum: {
             name: 'IAM Admin Count Minimum',
             description: 'The minimum number of IAM user admins to require in the account',
-            regex: '^[1-9]{1}[0-9]{0,3}$',
+            regex: '^[0-9]{0,4}$',
             default: 2
         },
         iam_admin_count_maximum: {
             name: 'IAM Admin Count Maximum',
             description: 'The maximum number of IAM user admins to require in the account',
-            regex: '^[1-9]{1}[0-9]{0,3}$',
+            regex: '^[0-9]{0,4}$',
             default: 2
         }
     },
 
     run: function(cache, settings, callback) {
         var config = {
-            iam_admin_count_minimum: settings.iam_admin_count_minimum || this.settings.iam_admin_count_minimum.default,
-            iam_admin_count_maximum: settings.iam_admin_count_maximum || this.settings.iam_admin_count_maximum.default
+            // using the `in` operator because 0 is a valid setting
+            iam_admin_count_minimum: 'iam_admin_count_minimum' in settings
+                ? parseInt(settings.iam_admin_count_minimum)
+                : this.settings.iam_admin_count_minimum.default,
+            iam_admin_count_maximum: 'iam_admin_count_maximum' in settings
+                ? parseInt(settings.iam_admin_count_maximum)
+                : this.settings.iam_admin_count_maximum.default,
         };
-
         var custom = helpers.isCustom(settings, this.settings);
 
         var results = [];
         var source = {};
-        
+
         var region = helpers.defaultRegion(settings);
 
         var listUsers = helpers.addSource(cache, source,
@@ -124,7 +128,7 @@ module.exports = {
                     var policy = listUserPolicies.data.PolicyNames[p];
 
                     if (getUserPolicy &&
-                        getUserPolicy[policy] && 
+                        getUserPolicy[policy] &&
                         getUserPolicy[policy].data &&
                         getUserPolicy[policy].data.PolicyDocument) {
 
@@ -163,7 +167,7 @@ module.exports = {
                     // Get inline policies attached to group
                     var listGroupPolicies = helpers.addSource(cache, source,
                             ['iam', 'listGroupPolicies', region, group.GroupName]);
-                    
+
                     var getGroupPolicy = helpers.addSource(cache, source,
                             ['iam', 'getGroupPolicy', region, group.GroupName]);
 
@@ -191,7 +195,7 @@ module.exports = {
                             var policy = listGroupPolicies.data.PolicyNames[p];
 
                             if (getGroupPolicy &&
-                                getGroupPolicy[policy] && 
+                                getGroupPolicy[policy] &&
                                 getGroupPolicy[policy].data &&
                                 getGroupPolicy[policy].data.PolicyDocument) {
 

--- a/plugins/aws/iam/iamUserAdmins.js
+++ b/plugins/aws/iam/iamUserAdmins.js
@@ -37,7 +37,7 @@ module.exports = {
     run: function(cache, settings, callback) {
         var config = {
             iam_admin_count_minimum: settings.iam_admin_count_minimum || this.settings.iam_admin_count_minimum.default,
-            iam_admin_count_maximum: settings.iam_admin_count_maximum || this.settings.iam_admin_count_maximum
+            iam_admin_count_maximum: settings.iam_admin_count_maximum || this.settings.iam_admin_count_maximum.default
         };
 
         var custom = helpers.isCustom(settings, this.settings);

--- a/plugins/aws/iam/iamUserAdmins.js
+++ b/plugins/aws/iam/iamUserAdmins.js
@@ -24,13 +24,13 @@ module.exports = {
             name: 'IAM Admin Count Minimum',
             description: 'The minimum number of IAM user admins to require in the account',
             regex: '^[1-9]{1}[0-9]{0,3}$',
-            default: 1
+            default: 2
         },
         iam_admin_count_maximum: {
             name: 'IAM Admin Count Maximum',
             description: 'The maximum number of IAM user admins to require in the account',
             regex: '^[1-9]{1}[0-9]{0,3}$',
-            default: 9
+            default: 2
         }
     },
 

--- a/plugins/aws/iam/iamUserAdmins.spec.js
+++ b/plugins/aws/iam/iamUserAdmins.spec.js
@@ -48,6 +48,7 @@ describe('iamUserAdmins', function () {
 
             const callback = (err, results) => {
                 expect(results.length).to.equal(1)
+                expect(results[0].status).to.equal(0)
                 done()
             }
 

--- a/plugins/aws/iam/iamUserAdmins.spec.js
+++ b/plugins/aws/iam/iamUserAdmins.spec.js
@@ -71,7 +71,7 @@ describe('iamUserAdmins', function () {
             }
 
             const cache = [{}];
-            
+
 
             const callback = (err, results) => {
                 expect(results.length).to.equal(0)
@@ -97,8 +97,8 @@ describe('iamUserAdmins', function () {
 
         it('should FAIL when there are too many users', function (done) {
             const settings = {
-                iam_admin_count_minimum: 1,
-                iam_admin_count_maximum: 1
+                iam_admin_count_minimum: 0,
+                iam_admin_count_maximum: 0
             }
 
             const callback = (err, results) => {
@@ -122,6 +122,5 @@ describe('iamUserAdmins', function () {
 
             iamUserAdmins.run(cache, settings, callback)
         })
-
     })
 })

--- a/plugins/aws/iam/iamUserAdmins.spec.js
+++ b/plugins/aws/iam/iamUserAdmins.spec.js
@@ -123,6 +123,5 @@ describe('iamUserAdmins', function () {
             iamUserAdmins.run(cache, settings, callback)
         })
 
-    
     })
 })

--- a/plugins/aws/iam/iamUserAdmins.spec.js
+++ b/plugins/aws/iam/iamUserAdmins.spec.js
@@ -1,0 +1,59 @@
+var assert = require('assert');
+var expect = require('chai').expect;
+var iamUserAdmins = require('./iamUserAdmins');
+
+const createCache = (users) => {
+    return {
+        iam: {
+            generateCredentialReport: {
+                'us-east-1': {
+                    data: users
+                }
+            }
+        }
+    }
+}
+
+describe('iamUserAdmins', function () {
+    describe('run', function () {
+        it('should FAIL when no users are found', function (done) {
+            const settings = {
+                iam_admin_count_minimum: 1,
+                iam_admin_count_maximum: 8
+            }
+
+            const cache = createCache(
+                [{}]
+            )
+
+            const callback = (err, results) => {
+                expect(results.length).to.equal(0)
+                done()
+            }
+
+            iamUserAdmins._run(cache, settings, callback)
+        })
+
+        it('should PASS when users are found and fit within range', function (done) {
+            const settings = {
+                iam_admin_count_minimum: 1,
+                iam_admin_count_maximum: 8
+            }
+
+            const cache = createCache(
+                [{
+                    user: '<root_account>'
+                }]
+            )
+
+            const callback = (err, results) => {
+                expect(results.length).to.equal(1)
+                done()
+            }
+
+            iamUserAdmins._run(cache, settings, callback)
+        })
+
+    
+    })
+})

--- a/plugins/aws/iam/iamUserAdmins.spec.js
+++ b/plugins/aws/iam/iamUserAdmins.spec.js
@@ -2,36 +2,111 @@ var assert = require('assert');
 var expect = require('chai').expect;
 var iamUserAdmins = require('./iamUserAdmins');
 
-const createCache = (users) => {
-    return {
-        iam: {
-            generateCredentialReport: {
-                'us-east-1': {
-                    data: users
+const cache =  {
+        "iam": {
+            "listUsers": {
+                "us-east-1": {
+                    "data": [
+                        {
+                        "UserName": "test1@turner.com",
+                        },
+                        {
+                        "UserName": "test2@turner.com",
+                        },
+                    ]
+                }
+            },
+            "listAttachedUserPolicies": {
+                "us-east-1": {
+                  "test1@turner.com": {
+                    "data": {
+                      "AttachedPolicies": [{"PolicyArn":"arn:aws:iam::aws:policy/AdministratorAccess"}],
+                    }
+                  },
+                  "test2@turner.com": {
+                    "data": {
+                      "AttachedPolicies": [{"PolicyArn":"arn:aws:iam::aws:policy/AdministratorAccess"}],
+                    }
+                  },
+                }
+            },
+            "listUserPolicies": {
+                "us-east-1": {
+                  "test1@turner.com": {
+                    "data": {
+                      "PolicyNames": [],
+                    }
+                  },
+                  "test2@turner.com": {
+                    "data": {
+                      "PolicyNames": [],
+                    }
+                  },
+                }
+            },
+            "listGroupsForUser": {
+                "us-east-1": {
+                    "test1@turner.com": {
+                        "data": {
+                          "Groups": [],
+                        }
+                      },
+                    "test2@turner.com": {
+                        "data": {
+                        "Groups": [],
+                        }
+                    },
                 }
             }
         }
     }
-}
+
 
 describe('iamUserAdmins', function () {
     describe('run', function () {
         it('should FAIL when no users are found', function (done) {
             const settings = {
-                iam_admin_count_minimum: 1,
-                iam_admin_count_maximum: 8
+                iam_admin_count_minimum: 2,
+                iam_admin_count_maximum: 2
             }
 
-            const cache = createCache(
-                [{}]
-            )
+            const cache = [{}];
+            
 
             const callback = (err, results) => {
                 expect(results.length).to.equal(0)
                 done()
             }
 
-            iamUserAdmins._run(cache, settings, callback)
+            iamUserAdmins.run(cache, settings, callback)
+        })
+
+        it('should FAIL when there are not enough users', function (done) {
+            const settings = {
+                iam_admin_count_minimum: 3,
+                iam_admin_count_maximum: 3
+            }
+
+            const callback = (err, results) => {
+                expect(results[0].status).to.equal(1)
+                done()
+            }
+
+            iamUserAdmins.run(cache, settings, callback)
+        })
+
+        it('should FAIL when there are too many users', function (done) {
+            const settings = {
+                iam_admin_count_minimum: 1,
+                iam_admin_count_maximum: 1
+            }
+
+            const callback = (err, results) => {
+                expect(results[0].status).to.equal(2)
+                done()
+            }
+
+            iamUserAdmins.run(cache, settings, callback)
         })
 
         it('should PASS when users are found and fit within range', function (done) {
@@ -40,19 +115,12 @@ describe('iamUserAdmins', function () {
                 iam_admin_count_maximum: 8
             }
 
-            const cache = createCache(
-                [{
-                    user: '<root_account>'
-                }]
-            )
-
             const callback = (err, results) => {
-                expect(results.length).to.equal(1)
                 expect(results[0].status).to.equal(0)
                 done()
             }
 
-            iamUserAdmins._run(cache, settings, callback)
+            iamUserAdmins.run(cache, settings, callback)
         })
 
     


### PR DESCRIPTION
The PR modifies the IAM User Admins check to allow user specified minimum and maximum number of IAM Users in an account. This allows an account managed via cross-account role or federation to be in compliance with no IAM Users.

This plugin was developed by Trek10 under contract to WarnerMedia for release back into the main CloudSploit Scanning Engine. WarnerMedia expressly authorizes their contribution.