### PR TITLE
Add --collection option that enables to save collected data

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ node index.js --json=./out.json
 # Output results in JUnit XML (suppressing the console output)
 node index.js --junit=./out.xml
 
+# Output collection results in JSON
+node index.js --collection=./collection.json
+
 # Output results only to the console (default if omitted)
 node index.js --console
 

--- a/engine.js
+++ b/engine.js
@@ -132,6 +132,7 @@ var engine = function (AWSConfig, AzureConfig, GitHubConfig, OracleConfig, Googl
 
         serviceProviderObj.collector(serviceProviderObj.config, settings, function (err, collection) {
             if (err || !collection) return console.log('ERROR: Unable to obtain API metadata');
+            outputHandler.writeCollection(collection, serviceProviderObj.name)
 
             console.log('');
             console.log('-----------------------');

--- a/postprocess/output.js
+++ b/postprocess/output.js
@@ -276,6 +276,26 @@ module.exports = {
     },
 
     /**
+     * Creates an output handler that writes collection in the JSON format.
+     * @param {fs.WriteSteam} stream The stream to write to or an object that
+     * obeys the writeable stream contract.
+     */
+    createCollection: function(stream) {
+        var results = {};
+        return {
+            stream: stream,
+
+            write: function (collection, providerName) {
+                results[providerName] = collection;
+            },
+
+            close: function () {
+                this.stream.write(JSON.stringify(results));
+                this.stream.end();
+            }
+        }
+    },
+    /**
      * Creates an output handler depending on the arguments list as expected
      * in the command line format. If multiple output handlers are specified
      * in the arguments, then constructs a unified view so that it appears that
@@ -290,6 +310,7 @@ module.exports = {
      */
     create: function (argv) {
         var outputs = [];
+        var collectionOutput;
 
         // Creates the handlers for writing output.
         var addCsvOutput = argv.find(function (arg) {
@@ -311,6 +332,15 @@ module.exports = {
         var addConsoleOutput = argv.find(function (arg) {
             return arg.startsWith('--console');
         })
+
+        var addCollectionOutput = argv.find(function(arg) {
+            return arg.startsWith('--collection=')
+        })
+        if(addCollectionOutput) {
+            var stream = fs.createWriteStream(addCollectionOutput.substr(13))
+            collectionOutput = this.createCollection(stream)
+        }
+
         // Write to console if specified or by default if there is not
         // other output handler specified.
         if (addConsoleOutput || outputs.length == 0) {
@@ -347,7 +377,16 @@ module.exports = {
                 }
             },
 
+            writeCollection: function(collection, providerName) {
+                if(collectionOutput) {
+                    collectionOutput.write(collection, providerName)
+                }
+            },
+
             close: function () {
+                if(collectionOutput) {
+                    collectionOutput.close()
+                }
                 for (var output of outputs) {
                     output.close();
                 }


### PR DESCRIPTION
This pull  request creates a new option `--collection` that enables to save the data collected throught API requests and save in a json. It's useful to summary all the data collected and debug purposes.

How to use:
`node index.js --collection=./all-my-data.json`