### PR TITLE
Configure via GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ if(process.env.GOOGLE_PROJECT_ID && process.env.GOOGLE_API_KEY){
     };
 }
 if(process.env.GOOGLE_APPLICATION_CREDENTIALS){
-    GoogleConfig = require(process.env.GOOGLE_APPLICATION_CREDENTIALS)
+    GoogleConfig = require(process.env.GOOGLE_APPLICATION_CREDENTIALS);
     GoogleConfig.project = GoogleConfig.project_id;
 }
 

--- a/index.js
+++ b/index.js
@@ -107,6 +107,10 @@ if(process.env.GOOGLE_PROJECT_ID && process.env.GOOGLE_API_KEY){
         region: process.env.GOOGLE_DEFAULT_REGION || 'us-east1'
     };
 }
+if(process.env.GOOGLE_APPLICATION_CREDENTIALS){
+    GoogleConfig = require(process.env.GOOGLE_APPLICATION_CREDENTIALS)
+    GoogleConfig.project = GoogleConfig.project_id;
+}
 
 // Custom settings - place plugin-specific settings here
 var settings = {};


### PR DESCRIPTION
Add a way to load a credential file via the env variable with the path to the file. This should make it easier to configure like in GCP [example](https://cloud.google.com/docs/authentication/getting-started).