### PR TITLE
plugins/google/vpcnetwork/ |  Fixed openSSH description typo

### DIFF
--- a/plugins/google/vpcnetwork/openSSH.js
+++ b/plugins/google/vpcnetwork/openSSH.js
@@ -4,7 +4,7 @@ var helpers = require('../../../helpers/google');
 module.exports = {
     title: 'Open SSH',
     category: 'VPC Network',
-    description: 'Determines if TCP port 22 for FTP is open to the public',
+    description: 'Determines if TCP port 22 for SSH is open to the public',
     more_info: 'While some ports such as HTTP and HTTPS are required to be open to the public to function properly, more sensitive services such as SSH should be restricted to known IP addresses.',
     link: 'https://cloud.google.com/vpc/docs/using-firewalls',
     recommended_action: 'Restrict TCP port 22 to known IP addresses.',


### PR DESCRIPTION
 Fixed the `plugins/google/vpcnetwork/openSSH.js` **description**, change from **FTP** to **SSH** service.
